### PR TITLE
feat(cli): add styled error output with a customisable error handler

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -17,6 +17,7 @@ type Option func(*options)
 type options struct {
 	ctx            context.Context
 	completion     *completionOptions
+	errHandler     ErrorHandler
 	manpages       bool
 	stdout         io.Writer
 	stderr         io.Writer
@@ -28,12 +29,13 @@ type options struct {
 
 func defaultOptions() *options {
 	return &options{
-		ctx:      context.Background(),
-		manpages: true,
-		stdout:   os.Stdout,
-		stderr:   os.Stderr,
-		theme:    DefaultTheme(),
-		width:    80,
+		ctx:        context.Background(),
+		errHandler: DefaultErrorHandler,
+		manpages:   true,
+		stdout:     os.Stdout,
+		stderr:     os.Stderr,
+		theme:      DefaultTheme(),
+		width:      80,
 	}
 }
 
@@ -56,6 +58,19 @@ func WithStdout(w io.Writer) Option {
 func WithStderr(w io.Writer) Option {
 	return func(o *options) {
 		o.stderr = w
+	}
+}
+
+// WithErrorHandler sets a custom error handler for rendering errors.
+// The handler is called when the command returns an error, receiving
+// the stderr writer, the configured theme, and the error.
+//
+//	cli.Execute(root, cli.WithErrorHandler(func(w io.Writer, theme cli.Theme, err error) {
+//	    fmt.Fprintln(w, err)
+//	}))
+func WithErrorHandler(handler ErrorHandler) Option {
+	return func(o *options) {
+		o.errHandler = handler
 	}
 }
 
@@ -236,6 +251,7 @@ func Execute(cmd *cobra.Command, opts ...Option) error {
 	cmd.SetHelpFunc(helpFunc(o.theme, o.width))
 	cmd.SetUsageFunc(usageFunc(o.theme, o.width))
 	cmd.SetHelpCommand(&cobra.Command{Hidden: true})
+	cmd.SilenceErrors = true
 	cmd.CompletionOptions.DisableDefaultCmd = true
 	cmd.TraverseChildren = true
 
@@ -278,5 +294,10 @@ func Execute(cmd *cobra.Command, opts ...Option) error {
 	}
 
 	addFlagRequirementsValidation(cmd)
-	return cmd.ExecuteContext(o.ctx)
+
+	if err := cmd.ExecuteContext(o.ctx); err != nil {
+		o.errHandler(o.stderr, o.theme, err)
+		return err
+	}
+	return nil
 }

--- a/cli/error.go
+++ b/cli/error.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// ErrorHandler renders an error to the given writer using the provided theme.
+type ErrorHandler func(w io.Writer, theme Theme, err error)
+
+// DefaultErrorHandler prints a styled ERROR badge followed by the error message.
+// For usage errors (unknown flags, missing arguments, etc.), it appends a hint
+// to try --help.
+func DefaultErrorHandler(w io.Writer, theme Theme, err error) {
+	fmt.Fprintln(w, theme.ErrorHeader.SetString("ERROR").String())
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, theme.ErrorDetails.Render(err.Error()))
+
+	if isUsageError(err) {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, theme.ErrorDetails.Render("Try --help for usage."))
+	}
+}
+
+// https://github.com/spf13/cobra/pull/2266
+func isUsageError(err error) bool {
+	s := err.Error()
+	for _, prefix := range []string{
+		"flag needs an argument:",
+		"unknown flag:",
+		"unknown shorthand flag:",
+		"unknown command",
+		"invalid argument",
+		"accepts ",
+		"required flag",
+	} {
+		if strings.HasPrefix(s, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/error_test.go
+++ b/cli/error_test.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/golden"
+)
+
+func TestDefaultErrorHandler(t *testing.T) {
+	var buf bytes.Buffer
+	theme := DefaultTheme()
+
+	DefaultErrorHandler(&buf, theme, errors.New("something went wrong"))
+
+	golden.Assert(t, buf.String(), "error.golden")
+}
+
+func TestDefaultErrorHandlerUsageError(t *testing.T) {
+	var buf bytes.Buffer
+	theme := DefaultTheme()
+
+	DefaultErrorHandler(&buf, theme, errors.New("unknown flag: --verbose"))
+
+	golden.Assert(t, buf.String(), "error_usage.golden")
+}
+
+func TestExecuteRendersStyledError(t *testing.T) {
+	cmd := &cobra.Command{
+		Use:   "myapp",
+		Short: "A test app",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return errors.New("something went wrong")
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := Execute(cmd, WithStdout(&stdout), WithStderr(&stderr))
+
+	require.Error(t, err)
+	golden.Assert(t, stderr.String(), "error.golden")
+}
+
+func TestExecuteWithCustomErrorHandler(t *testing.T) {
+	cmd := &cobra.Command{
+		Use:   "myapp",
+		Short: "A test app",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return errors.New("custom error")
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	handler := func(w io.Writer, _ Theme, err error) {
+		_, _ = io.WriteString(w, "CUSTOM: "+err.Error()+"\n")
+	}
+
+	err := Execute(cmd, WithStdout(&stdout), WithStderr(&stderr), WithErrorHandler(handler))
+
+	require.Error(t, err)
+	require.Equal(t, "CUSTOM: custom error\n", stderr.String())
+}
+
+func TestIsUsageError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "UnknownFlag",
+			err:      errors.New("unknown flag: --verbose"),
+			expected: true,
+		},
+		{
+			name:     "UnknownShorthandFlag",
+			err:      errors.New("unknown shorthand flag: 'v' in -v"),
+			expected: true,
+		},
+		{
+			name:     "FlagNeedsArgument",
+			err:      errors.New("flag needs an argument: --config"),
+			expected: true,
+		},
+		{
+			name:     "UnknownCommand",
+			err:      errors.New("unknown command \"foo\" for \"myapp\""),
+			expected: true,
+		},
+		{
+			name:     "InvalidArgument",
+			err:      errors.New("invalid argument \"foo\" for \"--count\""),
+			expected: true,
+		},
+		{
+			name:     "AcceptsArgs",
+			err:      errors.New("accepts between 1 and 3 arg(s), received 0"),
+			expected: true,
+		},
+		{
+			name:     "RequiredFlag",
+			err:      errors.New("required flag \"config\" not set"),
+			expected: true,
+		},
+		{
+			name:     "GenericError",
+			err:      errors.New("something went wrong"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, isUsageError(tt.err))
+		})
+	}
+}

--- a/cli/testdata/error.golden
+++ b/cli/testdata/error.golden
@@ -1,0 +1,3 @@
+ERROR
+
+something went wrong

--- a/cli/testdata/error_usage.golden
+++ b/cli/testdata/error_usage.golden
@@ -1,0 +1,5 @@
+ERROR
+
+unknown flag: --verbose
+
+Try --help for usage.

--- a/cli/theme.go
+++ b/cli/theme.go
@@ -41,20 +41,29 @@ type Theme struct {
 	// Operator styles shell operators in the EXAMPLES section
 	// (e.g., |, >, >>, <, &&, ||, ;).
 	Operator lipgloss.Style
+
+	// ErrorHeader styles the error badge (e.g., bold "ERROR" with a
+	// colored background).
+	ErrorHeader lipgloss.Style
+
+	// ErrorDetails styles the error message text that follows the badge.
+	ErrorDetails lipgloss.Style
 }
 
 // DefaultTheme returns a theme with no styling applied.
 func DefaultTheme() Theme {
 	return Theme{
-		Command:     lipgloss.NewStyle(),
-		Comment:     lipgloss.NewStyle(),
-		Description: lipgloss.NewStyle(),
-		EnvVar:      lipgloss.NewStyle(),
-		EnvVarValue: lipgloss.NewStyle(),
-		Flag:        lipgloss.NewStyle(),
-		FlagDefault: lipgloss.NewStyle(),
-		FlagType:    lipgloss.NewStyle(),
-		Header:      lipgloss.NewStyle(),
-		Operator:    lipgloss.NewStyle(),
+		Command:      lipgloss.NewStyle(),
+		Comment:      lipgloss.NewStyle(),
+		Description:  lipgloss.NewStyle(),
+		EnvVar:       lipgloss.NewStyle(),
+		EnvVarValue:  lipgloss.NewStyle(),
+		Flag:         lipgloss.NewStyle(),
+		FlagDefault:  lipgloss.NewStyle(),
+		FlagType:     lipgloss.NewStyle(),
+		Header:       lipgloss.NewStyle(),
+		Operator:     lipgloss.NewStyle(),
+		ErrorHeader:  lipgloss.NewStyle(),
+		ErrorDetails: lipgloss.NewStyle(),
 	}
 }


### PR DESCRIPTION
Closes #77

Add an `ErrorHandler` type and `DefaultErrorHandler` that renders a
styled ERROR header followed by the error message. Usage errors (unknown
flags, missing arguments, etc.) include a hint to try --help.

Signed-off-by: purpleclay <purpleclaygh@gmail.com>
