### PR TITLE
feat(cli): add dedicated EXIT CODES help section

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -13,6 +13,7 @@ go get github.com/purpleclay/x/cli
 - **Environment Variable Binding**: associate env vars with flags using cobra annotations, values are displayed in help if set
 - **Flag Grouping**: organize related flags into named sections
 - **Enum Flags**: type-safe enums with optional help text for each value
+- **Exit Codes**: document a command's exit codes in a dedicated help section
 - **Version Flag**: automatic `--version` flag and `version` subcommand support
 - **Shell Completion**: enhanced completions for 11 shells powered by [carapace](https://github.com/carapace-sh/carapace)
 
@@ -23,9 +24,11 @@ Deploy your application to the cloud with configurable options for environment,
 replicas, and resource limits.
 
 USAGE
+
   demo deploy [FLAGS]
 
 EXAMPLES
+
   # Deploy to staging with defaults
   demo deploy --env staging
 
@@ -33,6 +36,7 @@ EXAMPLES
   demo deploy --env production --replicas 5
 
 FLAGS
+
   -e, --env <string>
           target environment (default: "staging")
 
@@ -52,10 +56,18 @@ FLAGS
           - error: Errors only
 
 AUTHENTICATION
+
       --url <string>
           API endpoint URL
 
 GLOBAL FLAGS
+
   -c, --config <string>  [env: DEMO_CONFIG]
           path to config file
+
+EXIT CODES
+
+  0  success
+  1  drift detected
+  2  error
 ```

--- a/cli/exitcode.go
+++ b/cli/exitcode.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"sync"
+
+	"github.com/spf13/cobra"
+)
+
+// ExitCode documents a single exit code returned by a command, rendered
+// in a dedicated EXIT CODES section of the help output.
+type ExitCode struct {
+	Code int
+	Desc string
+}
+
+var (
+	exitCodeRegistryMu sync.RWMutex
+	exitCodeRegistry   = map[*cobra.Command][]ExitCode{}
+)
+
+// ExitCodes documents the exit codes a command can return, rendered as a
+// dedicated EXIT CODES section in the help output.
+//
+//	cli.ExitCodes(cmd,
+//	    cli.ExitCode{Code: 0, Desc: "success"},
+//	    cli.ExitCode{Code: 1, Desc: "drift detected"},
+//	    cli.ExitCode{Code: 2, Desc: "error"},
+//	)
+func ExitCodes(cmd *cobra.Command, codes ...ExitCode) {
+	cloned := append([]ExitCode(nil), codes...)
+
+	exitCodeRegistryMu.Lock()
+	exitCodeRegistry[cmd] = cloned
+	exitCodeRegistryMu.Unlock()
+}
+
+func getExitCodes(cmd *cobra.Command) []ExitCode {
+	exitCodeRegistryMu.RLock()
+	defer exitCodeRegistryMu.RUnlock()
+	return exitCodeRegistry[cmd]
+}

--- a/cli/help.go
+++ b/cli/help.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -60,6 +61,19 @@ func renderHelp(w io.Writer, cmd *cobra.Command, theme Theme, width int) {
 		fmt.Fprintln(w, theme.Header.Render("GLOBAL FLAGS"))
 		fmt.Fprintln(w)
 		renderFlags(w, cmd.InheritedFlags(), theme, width)
+	}
+
+	if codes := getExitCodes(cmd); len(codes) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, theme.Header.Render("EXIT CODES"))
+		fmt.Fprintln(w)
+		renderExitCodes(w, codes, theme)
+	}
+}
+
+func renderExitCodes(w io.Writer, codes []ExitCode, theme Theme) {
+	for _, c := range codes {
+		fmt.Fprintf(w, "  %s  %s\n", theme.FlagType.Render(strconv.Itoa(c.Code)), theme.Description.Render(c.Desc))
 	}
 }
 

--- a/cli/help_test.go
+++ b/cli/help_test.go
@@ -184,6 +184,29 @@ func TestHelpWithFlagGroups(t *testing.T) {
 	golden.Assert(t, buf.String(), "help_with_flag_groups.golden")
 }
 
+func TestHelpWithExitCodes(t *testing.T) {
+	var buf bytes.Buffer
+
+	cmd := &cobra.Command{
+		Use:   "deploy",
+		Short: "Deploy an application to the cloud",
+		Run:   func(_ *cobra.Command, _ []string) {},
+	}
+
+	ExitCodes(cmd,
+		ExitCode{Code: 0, Desc: "success"},
+		ExitCode{Code: 1, Desc: "drift detected"},
+		ExitCode{Code: 2, Desc: "error"},
+	)
+
+	cmd.SetArgs([]string{"--help"})
+
+	err := Execute(cmd, WithStdout(&buf))
+	require.NoError(t, err)
+
+	golden.Assert(t, buf.String(), "help_with_exit_codes.golden")
+}
+
 func TestHelpWithEnum(t *testing.T) {
 	var buf bytes.Buffer
 

--- a/cli/testdata/help_with_exit_codes.golden
+++ b/cli/testdata/help_with_exit_codes.golden
@@ -1,0 +1,16 @@
+Deploy an application to the cloud
+
+USAGE
+
+  deploy [FLAGS]
+
+FLAGS
+
+  -h, --help
+          help for deploy
+
+EXIT CODES
+
+  0  success
+  1  drift detected
+  2  error


### PR DESCRIPTION
closes #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command help output (via `--help`) now includes an **EXIT CODES** section when available, listing each exit code with a human-readable description.

* **Documentation**
  * Updated CLI documentation to include an **Exit Codes** help section, including example output for success, drift detected, and error codes.
  
* **Tests**
  * Added a golden snapshot test to verify the rendered help output including the **EXIT CODES** section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->