### PR TITLE
ci: switch to using the gpg import action

### DIFF
--- a/.github/workflows/nsv.yml
+++ b/.github/workflows/nsv.yml
@@ -27,10 +27,10 @@ jobs:
           cachix-token: ${{ secrets.GH_CACHIX }}
 
       - name: GPG Import
-        env:
-          GPG_PRIVATE_KEY: "${{ secrets.GPG_PRIVATE_KEY }}"
-          GPG_PASSPHRASE: "${{ secrets.GPG_PASSPHRASE }}"
-        run: nix run github:purpleclay/gpg-import
+        uses: purpleclay/gpg-import-action@a39506c3eff9b02459e033e3551e556934f266fc # v0
+        with:
+          key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Tag
         run: nix run github:purpleclay/nsv -- tag --show ${{ inputs.projects }}


### PR DESCRIPTION
closes #127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the signing key import step in the release workflow to use a pinned action and pull credentials directly from secure secrets.
  * Improved workflow consistency and reliability for release automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->